### PR TITLE
Add "name" Option to release method

### DIFF
--- a/lib/github_release_kit/cli.rb
+++ b/lib/github_release_kit/cli.rb
@@ -13,6 +13,7 @@ module GithubReleaseKit
     desc "release REPOSITORY_URL FILEPATH", "release kit"
     option :tag, :default => "nightly"
     option :retry, :type => :numeric, :default => 10
+    option :name
     def release(repository_url, filepath)
       filename = File.basename(filepath)
       init
@@ -33,6 +34,11 @@ module GithubReleaseKit
       Retriable.retriable tries: options[:retry] do
         p "retry"
         Octokit.upload_asset(nightly_release.url, filepath)
+      end
+
+      # Rename the release
+      unless options[:name].nil?
+        Octokit.update_release(nightly_release.url, :name => options[:name])
       end
     end
 


### PR DESCRIPTION
opentoonz/opentoonz#2009

After merging this I'm thinking of adding the following argument to the Jenkins' script:
```
...
bundle exec bin/github_release_kit release \
  --name nightly\ build\ $(TZ=UTC git log -1 --format=%cd --date=iso-strict|sed "s/T.*//") \
...
```

This change will (hopefully) rename a title of the nightly build release like `nightly build 2018-05-25` .