### PR TITLE
Try Removing Version Specifications 

### DIFF
--- a/github_release_kit.gemspec
+++ b/github_release_kit.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "thor"
   spec.add_dependency "mime-types"
-  spec.add_dependency "octokit", "~> 4.0"
+  spec.add_dependency "octokit"
   spec.add_dependency "retriable"
-  spec.add_development_dependency "bundler", "~> 1.11"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
This PR removes version specifications of dependencies as a trial, in order to resolve the recent Jenkins problem.